### PR TITLE
Add Binance trend chart server and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ototrend",
+  "version": "1.0.0",
+  "description": "Binance canlı verisiyle otomatik trend çizgisi sunan örnek uygulama.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No automated tests configured\""
+  },
+  "keywords": ["binance", "trend", "apexcharts"],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,164 @@
+const form = document.getElementById('query-form');
+const symbolInput = document.getElementById('symbol-input');
+const timeframeSelect = document.getElementById('timeframe-select');
+const limitInput = document.getElementById('limit-input');
+const statusEl = document.getElementById('status');
+const suggestionsList = document.getElementById('symbol-suggestions');
+
+let chart;
+let searchDebounce;
+
+function setStatus(message, isError = false) {
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.classList.toggle('status--error', Boolean(isError));
+}
+
+async function fetchSymbols(query) {
+  if (!query || query.length < 2) {
+    suggestionsList.innerHTML = '';
+    return;
+  }
+  try {
+    const res = await fetch(`/api/symbols?q=${encodeURIComponent(query)}`);
+    if (!res.ok) {
+      throw new Error('Sembol listesi alınamadı');
+    }
+    const data = await res.json();
+    suggestionsList.innerHTML = '';
+    data.symbols.forEach((item) => {
+      const option = document.createElement('option');
+      option.value = item.symbol;
+      option.label = `${item.baseAsset}/${item.quoteAsset}`;
+      suggestionsList.appendChild(option);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function buildChartOptions() {
+  return {
+    chart: {
+      id: 'trendChart',
+      type: 'candlestick',
+      height: 550,
+      toolbar: {
+        show: true,
+        tools: {
+          download: true,
+          zoom: true,
+          zoomin: true,
+          zoomout: true,
+          pan: true,
+          reset: true,
+        },
+      },
+    },
+    series: [
+      { name: 'Fiyat', type: 'candlestick', data: [] },
+      {
+        name: 'Trend',
+        type: 'line',
+        data: [],
+        color: '#f97316',
+      },
+    ],
+    plotOptions: {
+      candlestick: {
+        wick: {
+          useFillColor: true,
+        },
+      },
+    },
+    colors: ['#38bdf8'],
+    xaxis: {
+      type: 'datetime',
+    },
+    yaxis: {
+      tooltip: {
+        enabled: true,
+      },
+    },
+    tooltip: {
+      shared: true,
+      x: {
+        format: 'dd MMM HH:mm',
+      },
+    },
+    theme: {
+      mode: 'dark',
+    },
+  };
+}
+
+function updateChart({ candles, trendLine }, symbol, interval) {
+  if (!chart) {
+    chart = new ApexCharts(document.querySelector('#chart'), buildChartOptions());
+    chart.render();
+  }
+
+  const candleSeries = candles.map((item) => ({
+    x: new Date(item.time),
+    y: [item.open, item.high, item.low, item.close],
+  }));
+
+  const trendSeries = trendLine.map((point) => ({
+    x: new Date(point.x),
+    y: point.y,
+  }));
+
+  chart.updateSeries([
+    { name: 'Fiyat', type: 'candlestick', data: candleSeries },
+    { name: 'Trend', type: 'line', data: trendSeries, color: '#f97316' },
+  ]);
+
+  setStatus(
+    `${symbol} - ${interval.toUpperCase()} | Güncellenme: ${new Date().toLocaleTimeString()}`
+  );
+}
+
+async function loadData() {
+  const symbol = symbolInput.value.trim().toUpperCase();
+  const interval = timeframeSelect.value;
+  const limit = limitInput.value ? Number(limitInput.value) : 150;
+
+  if (!symbol) {
+    setStatus('Lütfen bir coin giriniz.', true);
+    return;
+  }
+
+  setStatus('Veriler yükleniyor...');
+  try {
+    const params = new URLSearchParams({ symbol, interval, limit: String(limit) });
+    const res = await fetch(`/api/klines?${params.toString()}`);
+    if (!res.ok) {
+      throw new Error('Veriler getirilemedi');
+    }
+    const data = await res.json();
+    if (!data.candles || data.candles.length === 0) {
+      setStatus('Seçilen kriterler için veri bulunamadı.', true);
+      return;
+    }
+    updateChart(data, symbol, interval);
+  } catch (err) {
+    console.error(err);
+    setStatus('Veri alınırken bir sorun oluştu.', true);
+  }
+}
+
+symbolInput.addEventListener('input', (event) => {
+  const value = event.target.value.trim();
+  clearTimeout(searchDebounce);
+  searchDebounce = setTimeout(() => fetchSymbols(value), 250);
+});
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  loadData();
+});
+
+window.addEventListener('load', () => {
+  loadData();
+  fetchSymbols(symbolInput.value.trim());
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OtoTrend - Binance Trend Çizici</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  </head>
+  <body>
+    <header class="header">
+      <h1>OtoTrend</h1>
+      <p>Binance canlı verisi ile otomatik trend çizgisi</p>
+    </header>
+
+    <main class="container">
+      <section class="controls">
+        <form id="query-form" class="controls__form">
+          <div class="field">
+            <label for="symbol-input">Coin</label>
+            <input
+              id="symbol-input"
+              name="symbol"
+              type="text"
+              list="symbol-suggestions"
+              placeholder="örn. BTCUSDT"
+              autocomplete="off"
+              value="BTCUSDT"
+              required
+            />
+            <datalist id="symbol-suggestions"></datalist>
+            <small class="field__hint">USDT pariteleri için arama yapabilirsiniz.</small>
+          </div>
+
+          <div class="field">
+            <label for="timeframe-select">Timeframe</label>
+            <select id="timeframe-select" name="interval">
+              <option value="1m">1 Dakika</option>
+              <option value="5m">5 Dakika</option>
+              <option value="15m">15 Dakika</option>
+              <option value="1h" selected>1 Saat</option>
+              <option value="4h">4 Saat</option>
+              <option value="1d">1 Gün</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="limit-input">Mum Sayısı</label>
+            <input
+              id="limit-input"
+              name="limit"
+              type="number"
+              min="30"
+              max="500"
+              value="150"
+            />
+          </div>
+
+          <button type="submit" class="button">Grafiği Göster</button>
+        </form>
+
+        <div class="status" id="status"></div>
+      </section>
+
+      <section class="chart-section">
+        <div id="chart"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Veriler Binance API üzerinden anlık olarak çekilmektedir. Grafik ApexCharts
+        kütüphanesi ile oluşturulmuştur.
+      </p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: dark light;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --bg: #0f172a;
+  --bg-light: #1e293b;
+  --text: #e2e8f0;
+  --accent: #38bdf8;
+  --border: rgba(148, 163, 184, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.2), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  letter-spacing: 0.05em;
+}
+
+.header p {
+  margin: 0.5rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.container {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: 0 1.5rem 2rem;
+}
+
+.controls {
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.controls__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field label {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.field input,
+.field select {
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-light);
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.3);
+  border-color: var(--accent);
+}
+
+.field__hint {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.button {
+  background: linear-gradient(120deg, #38bdf8, #22d3ee);
+  border: none;
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 0.7rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.25);
+}
+
+.status {
+  min-height: 48px;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.status--error {
+  color: #f87171;
+}
+
+.chart-section {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1rem;
+  min-height: 500px;
+}
+
+#chart {
+  width: 100%;
+  min-height: 500px;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+@media (max-width: 960px) {
+  .container {
+    grid-template-columns: 1fr;
+  }
+
+  .controls {
+    order: 1;
+  }
+
+  .chart-section {
+    order: 2;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,219 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+let symbolsCache = [];
+let lastSymbolsFetch = 0;
+const SYMBOL_CACHE_TTL = 1000 * 60 * 15; // 15 minutes
+
+function fetchJson(apiUrl) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(apiUrl, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Request failed: ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          try {
+            const body = Buffer.concat(chunks).toString('utf8');
+            const parsed = JSON.parse(body);
+            resolve(parsed);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      })
+      .on('error', (err) => {
+        reject(err);
+      });
+  });
+}
+
+async function getSymbols() {
+  const now = Date.now();
+  if (symbolsCache.length && now - lastSymbolsFetch < SYMBOL_CACHE_TTL) {
+    return symbolsCache;
+  }
+  const exchangeInfoUrl = 'https://api.binance.com/api/v3/exchangeInfo';
+  const data = await fetchJson(exchangeInfoUrl);
+  symbolsCache = (data.symbols || [])
+    .filter((symbol) => symbol.status === 'TRADING' && symbol.quoteAsset === 'USDT')
+    .map((symbol) => ({
+      symbol: symbol.symbol,
+      baseAsset: symbol.baseAsset,
+      quoteAsset: symbol.quoteAsset,
+    }));
+  lastSymbolsFetch = now;
+  return symbolsCache;
+}
+
+function linearRegression(values) {
+  const n = values.length;
+  if (n === 0) {
+    return { slope: 0, intercept: 0 };
+  }
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (let i = 0; i < n; i += 1) {
+    const x = i;
+    const y = values[i];
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denominator = n * sumXX - sumX * sumX;
+  if (denominator === 0) {
+    return { slope: 0, intercept: values[0] || 0 };
+  }
+  const slope = (n * sumXY - sumX * sumY) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+  return { slope, intercept };
+}
+
+async function handleSymbolsRequest(res, query) {
+  try {
+    const q = (query.q || '').toUpperCase();
+    const allSymbols = await getSymbols();
+    const filtered = q
+      ? allSymbols.filter(
+          (item) =>
+            item.symbol.includes(q) ||
+            item.baseAsset.includes(q) ||
+            item.quoteAsset.includes(q)
+        )
+      : allSymbols;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        symbols: filtered.slice(0, 30),
+        total: filtered.length,
+      })
+    );
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unable to fetch symbols', details: err.message }));
+  }
+}
+
+async function handleKlinesRequest(res, query) {
+  const symbol = (query.symbol || '').toUpperCase();
+  const interval = query.interval || '1h';
+  const limit = Math.min(parseInt(query.limit, 10) || 150, 500);
+  if (!symbol) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'symbol query parameter is required' }));
+    return;
+  }
+  const klinesUrl = `https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=${interval}&limit=${limit}`;
+  try {
+    const raw = await fetchJson(klinesUrl);
+    const candles = raw.map((item) => ({
+      time: item[0],
+      open: parseFloat(item[1]),
+      high: parseFloat(item[2]),
+      low: parseFloat(item[3]),
+      close: parseFloat(item[4]),
+      volume: parseFloat(item[5]),
+    }));
+    const closes = candles.map((c) => c.close);
+    const { slope, intercept } = linearRegression(closes);
+    const trendLine = candles.length
+      ? [
+          { x: candles[0].time, y: Number(intercept.toFixed(6)) },
+          {
+            x: candles[candles.length - 1].time,
+            y: Number((intercept + slope * (candles.length - 1)).toFixed(6)),
+          },
+        ]
+      : [];
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ candles, trendLine }));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unable to fetch klines', details: err.message }));
+  }
+}
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml; charset=utf-8';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function serveStaticFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': getContentType(filePath) });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+
+  if (parsedUrl.pathname === '/api/symbols' && req.method === 'GET') {
+    handleSymbolsRequest(res, parsedUrl.query);
+    return;
+  }
+
+  if (parsedUrl.pathname === '/api/klines' && req.method === 'GET') {
+    handleKlinesRequest(res, parsedUrl.query);
+    return;
+  }
+
+  const pathname = decodeURIComponent(parsedUrl.pathname || '/');
+  const sanitizedPath = path.normalize(pathname).replace(/^(\.{2}[\/])+/g, '');
+  let targetPath = path.join(PUBLIC_DIR, sanitizedPath);
+
+  if (pathname === '/' || path.extname(sanitizedPath) === '') {
+    targetPath = path.join(PUBLIC_DIR, 'index.html');
+  }
+
+  const resolvedPath = path.resolve(targetPath);
+
+  if (!resolvedPath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Forbidden');
+    return;
+  }
+
+  serveStaticFile(res, resolvedPath);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a lightweight Node.js server that proxies Binance data, caches symbol metadata, and serves the static client
- add an ApexCharts-based frontend with coin arama, timeframe selection, mum limiti girişi ve otomatik trend çizgisi
- style the uygulama and define npm metadata/scripts for kolay çalıştırma

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf2e224de8832b88362821a3354e82